### PR TITLE
Fix to pm2.json.rb template file

### DIFF
--- a/templates/pm2.json.erb
+++ b/templates/pm2.json.erb
@@ -1,7 +1,7 @@
 {
   "name":   "<%= @name %>",
   "script":    "<%= "#{@path}/current/node_modules/#{@name}/#{@script}" %>",
-  "args":   "<%= @args.to_a.to_json.gsub('"', "'") %>",
+  "args":   "<%= @args || @args.to_a.to_json.gsub('"', "'") %>",
   "env":    <%= @env || {}.to_json  %>,
   "error_file" : "/var/log/pm2/<%= @name %>/error.log",
   "out_file"   : "/var/log/pm2/<%= @name %>/out.log",


### PR DESCRIPTION
Use default arg if defined. Caused issue: "Detail: undefined method `to_json' for []:Array if using default arg values."
